### PR TITLE
Update the sitecheck script URL

### DIFF
--- a/hooks/moodle.py
+++ b/hooks/moodle.py
@@ -1,7 +1,7 @@
 import requests
 from api import API_PERMISSIONS
 
-HUBURL = "https://moodle.net/local/sitecheck/check.php"
+HUBURL = "https://stats.moodle.org/local/sitecheck/check.php"
 
 def process_pushnotification_payload(data):
     extra = data.get('extra', {})


### PR DESCRIPTION
The script is now part of the new https://stats.moodle.org/ site. We have a redirect in place, but it would help to start using the new URL so that we can get rid of the redirect rule.